### PR TITLE
Update supported-languages.md

### DIFF
--- a/docs/software/supported-languages.md
+++ b/docs/software/supported-languages.md
@@ -93,7 +93,7 @@ To install the package manager, enter the following commands:
 
 ```Shell
 opkg update
-opkg install python-pip
+opkg install python3-pip
 ```
 
 To install using PIP, enter the following command:


### PR DESCRIPTION
change python-pip installation command to python3-pip since python2 is not supported on openwrt 23.05